### PR TITLE
🔨 3_Footer_컴포넌트) Footer 컴포넌트를 만들고 하단에 고정시키기

### DIFF
--- a/src/component/Global/Footer.tsx
+++ b/src/component/Global/Footer.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from "react";
 
-function Footer({ isNeededToBeFixed }: { isNeededToBeFixed: boolean }) {
-    const fixedCss = `${isNeededToBeFixed ? "fixed bottom-0" : "block"}`;
+function Footer() {
+    // const fixedCss = `${isNeededToBeFixed ? "fixed bottom-0" : "block"}`;
     return (
-        <footer
-            className={`flex flex-col justify-center items-center ${fixedCss} w-screen h-14 border-t border-light-black`}
-        >
+        <footer className={`flex flex-col justify-center items-center w-screen h-14 border-t border-light-black`}>
             <p className="text-xs text-light-text">개인정보 처리방침 | 이용 약관</p>
             <p className="text-xs text-light-text">All rights reserved @ Codestates</p>
         </footer>

--- a/src/component/Global/Footer.tsx
+++ b/src/component/Global/Footer.tsx
@@ -1,0 +1,15 @@
+import React, { useEffect, useState } from "react";
+
+function Footer({ isNeededToBeFixed }: { isNeededToBeFixed: boolean }) {
+    const fixedCss = `${isNeededToBeFixed ? "fixed bottom-0" : "block"}`;
+    return (
+        <footer
+            className={`flex flex-col justify-center items-center ${fixedCss} w-screen h-14 border-t border-light-black`}
+        >
+            <p className="text-xs text-light-text">개인정보 처리방침 | 이용 약관</p>
+            <p className="text-xs text-light-text">All rights reserved @ Codestates</p>
+        </footer>
+    );
+}
+
+export default Footer;

--- a/src/component/Global/Header.tsx
+++ b/src/component/Global/Header.tsx
@@ -14,7 +14,7 @@ function Header() {
     const [isDropDownShow, setIsDropDownShow] = useRecoilState(dropdownShow);
 
     return (
-        <div className="flex justify-between items-center w-full h-20 px-76px">
+        <header className="flex justify-between items-center w-full h-20 px-76px">
             <Link to="/">
                 <div className="flex items-center cursor-pointer">
                     <div className="w-55px h-30px pr-3">
@@ -33,7 +33,7 @@ function Header() {
                     <MenuDropDownItem />
                 </CDropDown>
             </div>
-        </div>
+        </header>
     );
 }
 

--- a/src/container/Container.tsx
+++ b/src/container/Container.tsx
@@ -1,12 +1,41 @@
-import React from "react";
+import React, { useRef, RefObject, useState, useEffect } from "react";
 import { Outlet } from "react-router";
 import Header from "@component/Global/Header";
+import Footer from "@component/Global/Footer";
+
+import { useElementWidthAndHeight } from "@hook/useElementWidthAndHeight";
+import { useSceenWidthAndHeight } from "@hook/useScreenWidthAndHeight";
 
 function Container() {
+    // prettier-ignore
+    const mainRef: RefObject<HTMLElement> = useRef<HTMLElement>(null);
+
+    const screenRect = useSceenWidthAndHeight();
+    const elementRect = useElementWidthAndHeight(mainRef);
+
+    const [isNeededToBeFixed, setIsNeededToBeFixed] = useState(false);
+
+    useEffect(() => {
+        // main 의 height가 짧을 경우 Footer 를 하단에 고정시키기 위함
+        // screen.height: 스크린의 height
+        // main.height: Header와 Footer를 제외한 main 엘리먼트의 전체 height
+        // 80: Header의 height
+        // 58: Footer의 height
+        const temp = screenRect.height - elementRect.height - 80 - 58;
+        if (temp && temp > 0) {
+            setIsNeededToBeFixed(true);
+        } else {
+            setIsNeededToBeFixed(false);
+        }
+    }, [elementRect.height, screenRect.height]);
+
     return (
         <>
             <Header />
-            <Outlet />
+            <main ref={mainRef}>
+                <Outlet />
+            </main>
+            <Footer isNeededToBeFixed={isNeededToBeFixed} />
         </>
     );
 }

--- a/src/container/Container.tsx
+++ b/src/container/Container.tsx
@@ -11,9 +11,9 @@ function Container() {
     const mainRef: RefObject<HTMLElement> = useRef<HTMLElement>(null);
 
     const screenRect = useSceenWidthAndHeight();
-    const elementRect = useElementWidthAndHeight(mainRef);
 
-    const [isNeededToBeFixed, setIsNeededToBeFixed] = useState(false);
+    // prettier-ignore
+    const [mainHeight, setMainHeight] = useState<number>(0);
 
     useEffect(() => {
         // main 의 height가 짧을 경우 Footer 를 하단에 고정시키기 위함
@@ -21,21 +21,17 @@ function Container() {
         // main.height: Header와 Footer를 제외한 main 엘리먼트의 전체 height
         // 80: Header의 height
         // 58: Footer의 height
-        const temp = screenRect.height - elementRect.height - 80 - 58;
-        if (temp && temp > 0) {
-            setIsNeededToBeFixed(true);
-        } else {
-            setIsNeededToBeFixed(false);
-        }
-    }, [elementRect.height, screenRect.height]);
+        const temp = screenRect.height - 80 - 58;
+        setMainHeight(temp);
+    }, [screenRect.height]);
 
     return (
         <>
             <Header />
-            <main ref={mainRef}>
+            <main ref={mainRef} style={{ minHeight: mainHeight + "px" }}>
                 <Outlet />
             </main>
-            <Footer isNeededToBeFixed={isNeededToBeFixed} />
+            <Footer />
         </>
     );
 }

--- a/src/hook/useElementWidthAndHeight.ts
+++ b/src/hook/useElementWidthAndHeight.ts
@@ -1,0 +1,32 @@
+import React, { useEffect, useState, RefObject } from "react";
+
+/**
+ * 엘리먼트의 전체 width와 height를 반환시키는 훅
+ * @param ref 크기를 확인하고 싶은 앨리먼트의 ref
+ * @returns {object<width: number, height: number>} ref로 받은 컴포넌트의 width와 heigth
+ */
+export const useElementWidthAndHeight = (ref: RefObject<HTMLElement>) => {
+    // prettier-ignore
+    const [width, setWidth] = useState<number>(0);
+    // prettier-ignore
+    const [height, setHeight] = useState<number>(0);
+
+    useEffect(() => {
+        const setElementClientWidthHeight = () => {
+            if (ref.current) {
+                const refStyle = window.getComputedStyle(ref.current);
+                const width = refStyle.getPropertyValue("width");
+                const height = refStyle.getPropertyValue("height");
+
+                setWidth(Number.parseInt(width.split("px")[0]));
+                setHeight(Number.parseInt(height.split("px")[0]));
+            }
+        };
+
+        setElementClientWidthHeight();
+    }, []);
+
+    const clientRects = { width, height };
+
+    return clientRects;
+};

--- a/src/hook/useScreenWidthAndHeight.ts
+++ b/src/hook/useScreenWidthAndHeight.ts
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react";
+
+/**
+ * resize 이벤트 발생 시 바뀐 clientWidth, clientHeight를 반환
+ * @returns {object<width: number, height: number>} ref로 받은 컴포넌트의 width와 heigth
+ */
+export const useSceenWidthAndHeight = () => {
+    // prettier-ignore
+    const [width, setWidth] = useState<number>(0);
+    // prettier-ignore
+    const [height, setHeight] = useState<number>(0);
+
+    useEffect(() => {
+        const setScreenWidthHeight = () => {
+            setWidth(window.innerWidth);
+            setHeight(window.innerHeight);
+        };
+
+        setScreenWidthHeight();
+
+        window.addEventListener("resize", setScreenWidthHeight);
+
+        return () => {
+            window.removeEventListener("resize", setScreenWidthHeight);
+        };
+    }, []);
+
+    const clientRects = { width, height };
+
+    return clientRects;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,7 @@ export default {
             },
             colors: {
                 "light-black": "#ffffffa",
-                background: "#888888",
+                "light-text": "#888888",
                 violet: "#452CDD",
             },
             borderWidth: {


### PR DESCRIPTION
### [어디까지 구현했는지]
- 프로젝트 세팅 + Header 컴포넌트 + Recoil 세팅

### [현재 어딜 구현하고 있는지]
issues #13 

Figma 시안
<img width="869" alt="image" src="https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/efb0d5a4-5cdc-4310-9ef4-65a5930aa24b">

결과
<img width="869" alt="image" src="https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/93d5c0b9-8f00-4091-9062-bae95324210b">

이슈사항
- Footer의 위치
  - Case1. Header 컴포넌트 높이 +  Footer 컴포넌트 높이 + main 영역 높이 < screen 높이 일 경우
    - Footer는 하단에 고정
  - Case2. Header 컴포넌트 높이 +  Footer 컴포넌트 높이 + main 영역 높이 > screen 높이 일 경우
    - Footer는 main 영역 하단에 위치

이를 적용하기 위해 사용한 방법 1.
1. screen의 높이를 custom hook을 통해 가져옵니다. (useSceenWidthAndHeight)
2. main의 높이를 custom hook을 통해 가져옵니다. (useElementWidthAndHeight)
3. Case1의 경우 Footer의 display를 fixed, bottom을 0으로 하여 하단에 고정시킵니다.
4. Case2의 경우 Footer의 display를 flex로 하여 main 영역 하단에 위치하도록 합니다.

=> Refactor : min-height를 사용하면 screen의 높이만 가져와도 Footer를 하단에 고정시킬 수 있겠다!

이를 적용하기 위해 사용한 방법 2.
1. screen의 높이를 custom hook을 통해 가져옵니다. (useSceenWidthAndHeight)
2. main 영역의 min-height를 지정해줍니다. (screen 높이 - Header 높이 - Footer의 높이)

두번째 방법이 보다 명시적이고 간편하고 불필요한 hook 호출을 줄이기 때문에 리팩토링하였습니다.

<img width="1470" alt="image" src="https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/f5a70420-1641-43c4-adee-a36c9c6a0c2d">


### [앞으로 어딜 구현할 것인지]
- GNB 컴포넌트

### [집중적으로 코드 리뷰를 받고 싶거나 궁금한 부분]
