### PR TITLE
♻️ 10_북마크_bugfix) 북마크 관련 에러 수정 및 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.4.0",
+        "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.10.1",
@@ -2537,6 +2538,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5383,6 +5389,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "recoil": "^0.7.7"
       },
       "devDependencies": {
+        "@types/lodash": "^4.14.195",
         "@types/node": "^20.4.1",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
@@ -962,6 +963,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -4279,6 +4286,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "recoil": "^0.7.7"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.195",
     "@types/node": "^20.4.1",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ const router = createBrowserRouter([
             },
             {
                 path: "/products/list",
-                element: <ProductList isMain={false} />,
+                element: <ProductList />,
             },
             {
                 path: "/bookmark",

--- a/src/api/ProductList/index.ts
+++ b/src/api/ProductList/index.ts
@@ -1,9 +1,18 @@
 import { commonApi } from "@api/common";
 
-export const reqProductList = ({ count }: { count: number }) => {
+/**
+ *
+ * @param {number | null} count; nunmber-size조절 parameter/null-전체
+ * @returns
+ */
+export const reqProductList = ({ count }: { count: number | null }) => {
     const method = "GET";
     const path = "products";
     const params = { count };
 
     return commonApi({ method, path, params });
+};
+
+export const reqAllProductList = () => {
+    return reqProductList({ count: null });
 };

--- a/src/component/Common/CBookmarkBtn.tsx
+++ b/src/component/Common/CBookmarkBtn.tsx
@@ -6,6 +6,8 @@ import { addBookmark, removeBookmark } from "@recoil/Bookmark";
 
 import { useToast } from "@hook/useToast";
 
+import _ from "lodash";
+
 import { IProductItemWithBookmark } from "@type/ProductList";
 
 import { AiFillStar } from "react-icons/ai";
@@ -25,9 +27,7 @@ function CBookmarkBtn({
 
     const changeIsBookmarkedStatusFn = useSetRecoilState(changeIsBookmarkedStatus(item.id));
 
-    const handleBookmarkClick = (e: React.MouseEvent<HTMLElement>) => {
-        e.stopPropagation();
-
+    const handleBookmarkClick = _.debounce((e: React.MouseEvent<HTMLElement>) => {
         let content = { color: "", text: "" };
         if (isBookmarked) {
             removeBookmarkFn([{ ...item }]);
@@ -45,10 +45,16 @@ function CBookmarkBtn({
             ),
         });
         changeIsBookmarkedStatusFn([]);
-    };
+    }, 400);
 
     return (
-        <button className={btnStyle} onClick={handleBookmarkClick}>
+        <button
+            className={btnStyle}
+            onClick={(e) => {
+                e.stopPropagation();
+                handleBookmarkClick(e);
+            }}
+        >
             {isBookmarked ? <AiFillStar size={"2rem"} color="#FFD361" /> : <AiFillStar size={"2rem"} color="#e8e8e8" />}
         </button>
     );

--- a/src/component/Common/CBookmarkBtn.tsx
+++ b/src/component/Common/CBookmarkBtn.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import { useSetRecoilState } from "recoil";
+import { changeIsBookmarkedStatus } from "@recoil/ProductList";
+import { addBookmark, removeBookmark } from "@recoil/Bookmark";
+
+import { useToast } from "@hook/useToast";
+
+import { IProductItemWithBookmark } from "@type/ProductList";
+
+import { AiFillStar } from "react-icons/ai";
+
+function CBookmarkBtn({
+    btnStyle,
+    isBookmarked,
+    item,
+}: {
+    btnStyle: string,
+    isBookmarked: boolean,
+    item: IProductItemWithBookmark,
+}) {
+    const { fireToast } = useToast();
+    const addBookmarkFn = useSetRecoilState(addBookmark);
+    const removeBookmarkFn = useSetRecoilState(removeBookmark);
+
+    const changeIsBookmarkedStatusFn = useSetRecoilState(changeIsBookmarkedStatus(item.id));
+
+    const handleBookmarkClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
+
+        let content = { color: "", text: "" };
+        if (isBookmarked) {
+            removeBookmarkFn([{ ...item }]);
+            content = { color: "#e8e8e8", text: "상품이 북마크에서 삭제되었습니다" };
+        } else {
+            addBookmarkFn([{ ...item, isBookmarked: true }]);
+            content = { color: "#FFD361", text: "상품이 북마크에 추가되었습니다" };
+        }
+        fireToast({
+            content: (
+                <div className="flex items-center">
+                    <AiFillStar size={"2rem"} color={content.color} />
+                    <p>{content.text}</p>
+                </div>
+            ),
+        });
+        changeIsBookmarkedStatusFn([]);
+    };
+
+    return (
+        <button className={btnStyle} onClick={handleBookmarkClick}>
+            {isBookmarked ? <AiFillStar size={"2rem"} color="#FFD361" /> : <AiFillStar size={"2rem"} color="#e8e8e8" />}
+        </button>
+    );
+}
+
+export default CBookmarkBtn;

--- a/src/component/Common/CDropDown.tsx
+++ b/src/component/Common/CDropDown.tsx
@@ -16,7 +16,7 @@ function CDropDown({ height, children }: { height: string, children: JSX.Element
 
     return (
         <div
-            style={{ height: `${show ? height : "0"}`, transition: "height ease-out 500ms 0s" }}
+            style={{ height: `${show ? height : "0"}`, transition: "height ease-out 100ms 0s" }}
             className={`absolute z-20 right-52px w-max overflow-hidden ${triangleBeforeCss} ${triangleAfterCss}`}
         >
             <ol className={`${olDefaultCss}`}>{children}</ol>

--- a/src/component/Common/CNoContent.tsx
+++ b/src/component/Common/CNoContent.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function CNoContent({ message }: { message: string | JSX.Element }) {
+    return <div className="flex justify-center items-center w-screen h-210px">{message}</div>;
+}
+
+export default CNoContent;

--- a/src/component/Common/CProductItem.tsx
+++ b/src/component/Common/CProductItem.tsx
@@ -1,15 +1,10 @@
 import React, { useState } from "react";
 
-import { useSetRecoilState } from "recoil";
-import { changeIsBookmarkedStatus } from "@recoil/ProductList";
-import { addBookmark, removeBookmark } from "@recoil/Bookmark";
-
 import CModal from "@component/Common/CModal";
+import CBookmarkBtn from "@component/Common/CBookmarkBtn";
 import ProductModal from "@component/ProductList/ProductModal";
 import PreparingImage from "@asset/preparing-image.jpeg";
-import { AiFillStar } from "react-icons/ai";
 
-import { useToast } from "@hook/useToast";
 import { useProductInfo } from "@hook/useProductInfo";
 
 import { IProductItemWithBookmark } from "@type/ProductList";
@@ -19,35 +14,8 @@ function CProductItem(props: { item: IProductItemWithBookmark }) {
 
     const [isOpen, setIsOpen] = useState(false);
 
-    const { fireToast } = useToast();
-    const addBookmarkFn = useSetRecoilState(addBookmark);
-    const removeBookmarkFn = useSetRecoilState(removeBookmark);
-
-    const changeIsBookmarkedStatusFn = useSetRecoilState(changeIsBookmarkedStatus(id));
-
     const productInfo = useProductInfo({ item: props.item });
-
-    const handleBookmarkClick = (e: React.MouseEvent<HTMLElement>) => {
-        e.stopPropagation();
-
-        let content = { color: "", text: "" };
-        if (isBookmarked) {
-            removeBookmarkFn([{ ...props.item }]);
-            content = { color: "#e8e8e8", text: "상품이 북마크에서 삭제되었습니다" };
-        } else {
-            addBookmarkFn([{ ...props.item, isBookmarked: true }]);
-            content = { color: "#FFD361", text: "상품이 북마크에 추가되었습니다" };
-        }
-        fireToast({
-            content: (
-                <div className="flex items-center">
-                    <AiFillStar size={"2rem"} color={content.color} />
-                    <p>{content.text}</p>
-                </div>
-            ),
-        });
-        changeIsBookmarkedStatusFn([]);
-    };
+    const btnStyle = "absolute bottom-16 right-3";
 
     return (
         <>
@@ -71,13 +39,7 @@ function CProductItem(props: { item: IProductItemWithBookmark }) {
                     <p>{productInfo?.subTitle || ""}</p>
                     <p>{productInfo?.subInfo || ""}</p>
                 </div>
-                <button className="absolute bottom-16 right-3" onClick={handleBookmarkClick}>
-                    {isBookmarked ? (
-                        <AiFillStar size={"2rem"} color="#FFD361" />
-                    ) : (
-                        <AiFillStar size={"2rem"} color="#e8e8e8" />
-                    )}
-                </button>
+                <CBookmarkBtn btnStyle={btnStyle} isBookmarked={!!isBookmarked} item={props.item} />
             </figure>
             {isOpen ? (
                 <CModal setIsOpen={setIsOpen}>

--- a/src/component/Common/CProductItem.tsx
+++ b/src/component/Common/CProductItem.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { useSetRecoilState } from "recoil";
+import { changeIsBookmarkedStatus } from "@recoil/ProductList";
 import { addBookmark, removeBookmark } from "@recoil/Bookmark";
 
 import CModal from "@component/Common/CModal";
@@ -17,16 +18,35 @@ function CProductItem(props: { item: IProductItemWithBookmark }) {
     const { id, type, isBookmarked } = props.item;
 
     const [isOpen, setIsOpen] = useState(false);
-    const [bookmarked, setBookmarked] = useState(!!isBookmarked);
 
     const { fireToast } = useToast();
     const addBookmarkFn = useSetRecoilState(addBookmark);
     const removeBookmarkFn = useSetRecoilState(removeBookmark);
 
+    const changeIsBookmarkedStatusFn = useSetRecoilState(changeIsBookmarkedStatus(id));
 
+    const productInfo = useProductInfo({ item: props.item });
 
+    const handleBookmarkClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
 
+        let content = { color: "", text: "" };
+        if (isBookmarked) {
+            removeBookmarkFn([{ ...props.item }]);
+            content = { color: "#e8e8e8", text: "상품이 북마크에서 삭제되었습니다" };
+        } else {
+            addBookmarkFn([{ ...props.item, isBookmarked: true }]);
+            content = { color: "#FFD361", text: "상품이 북마크에 추가되었습니다" };
         }
+        fireToast({
+            content: (
+                <div className="flex items-center">
+                    <AiFillStar size={"2rem"} color={content.color} />
+                    <p>{content.text}</p>
+                </div>
+            ),
+        });
+        changeIsBookmarkedStatusFn([]);
     };
 
     return (
@@ -51,36 +71,8 @@ function CProductItem(props: { item: IProductItemWithBookmark }) {
                     <p>{productInfo?.subTitle || ""}</p>
                     <p>{productInfo?.subInfo || ""}</p>
                 </div>
-                <button
-                    className="absolute bottom-16 right-3"
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        if (bookmarked) {
-                            removeBookmarkFn([{ ...props.item }]);
-                            setBookmarked(false);
-                            fireToast({
-                                content: (
-                                    <div className="flex items-center">
-                                        <AiFillStar size={"2rem"} color="#e8e8e8" />
-                                        <p>상품이 북마크에서 제거되었습니다.</p>
-                                    </div>
-                                ),
-                            });
-                        } else {
-                            addBookmarkFn([{ ...props.item, isBookmarked: true }]);
-                            setBookmarked(true);
-                            fireToast({
-                                content: (
-                                    <div className="flex items-center">
-                                        <AiFillStar size={"2rem"} color="#FFD361" />
-                                        <p>상품이 북마크에 추가되었습니다.</p>
-                                    </div>
-                                ),
-                            });
-                        }
-                    }}
-                >
-                    {bookmarked ? (
+                <button className="absolute bottom-16 right-3" onClick={handleBookmarkClick}>
+                    {isBookmarked ? (
                         <AiFillStar size={"2rem"} color="#FFD361" />
                     ) : (
                         <AiFillStar size={"2rem"} color="#e8e8e8" />

--- a/src/component/Common/CProductItem.tsx
+++ b/src/component/Common/CProductItem.tsx
@@ -85,6 +85,8 @@ function CProductItem(props: { item: IProductItemWithBookmark }) {
                         img={productInfo.img || PreparingImage}
                         title={productInfo.title || ""}
                         setIsOpen={setIsOpen}
+                        isBookmarked={!!isBookmarked}
+                        item={props.item}
                     />
                 </CModal>
             ) : null}

--- a/src/component/Common/CProductItem.tsx
+++ b/src/component/Common/CProductItem.tsx
@@ -9,27 +9,13 @@ import PreparingImage from "@asset/preparing-image.jpeg";
 import { AiFillStar } from "react-icons/ai";
 
 import { useToast } from "@hook/useToast";
+import { useProductInfo } from "@hook/useProductInfo";
 
-import { IProductInfo, IProductItemWithBookmark } from "@type/ProductList";
-import { PRODUCT_TYPE } from "@constant/ProductList";
+import { IProductItemWithBookmark } from "@type/ProductList";
 
 function CProductItem(props: { item: IProductItemWithBookmark }) {
-    const {
-        id,
-        title,
-        sub_title,
-        price,
-        image_url,
-        brand_name,
-        brand_image_url,
-        follower,
-        discountPercentage,
-        type,
-        isBookmarked,
-    } = props.item;
+    const { id, type, isBookmarked } = props.item;
 
-    // prettier-ignore
-    const [productInfo, setProductInfo] = useState<IProductInfo>({});
     const [isOpen, setIsOpen] = useState(false);
     const [bookmarked, setBookmarked] = useState(!!isBookmarked);
 
@@ -37,53 +23,11 @@ function CProductItem(props: { item: IProductItemWithBookmark }) {
     const addBookmarkFn = useSetRecoilState(addBookmark);
     const removeBookmarkFn = useSetRecoilState(removeBookmark);
 
-    const infoWidthCategory = () => {
-        if (type === PRODUCT_TYPE.PRODUCT) {
-            return {
-                title: title,
-                subTitle: sub_title,
-                info: `${discountPercentage || 0}%`,
-                subInfo: `${Number.parseInt(price || "0").toLocaleString()}원`,
-                img: image_url,
-            };
-        }
 
-        if (type === PRODUCT_TYPE.CATEGORY) {
-            return {
-                title: `#${title}`,
-                subTitle: "",
-                info: "",
-                subInfo: "",
-                img: image_url,
-            };
-        }
 
-        if (type === PRODUCT_TYPE.EXHIBITION) {
-            return {
-                title: title,
-                subTitle: "",
-                info: `${discountPercentage || 0}%`,
-                subInfo: "",
-                img: image_url,
-            };
-        }
 
-        if (type === PRODUCT_TYPE.BRAND) {
-            return {
-                title: brand_name,
-                subTitle: "",
-                info: "관심고객수",
-                subInfo: `${(follower || 0).toLocaleString()}명`,
-                img: brand_image_url,
-            };
         }
-
-        return {};
     };
-
-    useEffect(() => {
-        setProductInfo(infoWidthCategory());
-    }, []);
 
     return (
         <>
@@ -96,7 +40,7 @@ function CProductItem(props: { item: IProductItemWithBookmark }) {
                     <img
                         className="w-full h-full hover:scale-125 transition-all duration-400"
                         src={productInfo?.img || PreparingImage}
-                        alt={`${title} 이미지`}
+                        alt={`${productInfo?.title || ""} 이미지`}
                     />
                 </div>
                 <figcaption className="flex justify-between items-center h-6">

--- a/src/component/Global/Gnb.tsx
+++ b/src/component/Global/Gnb.tsx
@@ -30,7 +30,7 @@ function Gnb() {
         {
             id: 2,
             label: "카테고리",
-            type: "Cateogry",
+            type: "Category",
             img: IconCategory,
             isSelected: false,
         },

--- a/src/component/Global/Gnb.tsx
+++ b/src/component/Global/Gnb.tsx
@@ -6,48 +6,52 @@ import IconCategory from "@asset/icon-category.png";
 import IconExhibition from "@asset/icon-exhibition.png";
 import IconBrand from "@asset/icon-category.png";
 
-interface IGnbItems {
-    id: number;
-    label: string;
-    img: string;
-    isSelected: boolean;
-}
+import { useSetRecoilState } from "recoil";
+import { selectedGnbType } from "@recoil/Global";
+
+import { IGnbItems } from "@type/Global";
 
 function Gnb() {
     const gnbItems: Array<IGnbItems> = [
         {
             id: 0,
             label: "전체",
+            type: "",
             img: IconAll,
             isSelected: true,
         },
         {
             id: 1,
             label: "상품",
+            type: "Product",
             img: IconProduct,
             isSelected: false,
         },
         {
             id: 2,
             label: "카테고리",
+            type: "Cateogry",
             img: IconCategory,
             isSelected: false,
         },
         {
             id: 3,
             label: "기획전",
+            type: "Exhibition",
             img: IconExhibition,
             isSelected: false,
         },
         {
             id: 4,
             label: "브랜드",
+            type: "Brand",
             img: IconBrand,
             isSelected: false,
         },
     ];
 
     const [gnbMenu, setGnbMenu] = useState(gnbItems);
+    const setSelectedType = useSetRecoilState(selectedGnbType);
 
     return (
         <div className="flex justify-center mb-6">
@@ -59,8 +63,9 @@ function Gnb() {
                             i !== gnbItems.length - 1 ? "mr-9" : ""
                         } cursor-pointer hover:font-bold hover:text-violet`}
                         onClick={() => {
-                            const selectedIdx = i;
+                            setSelectedType(v.type);
 
+                            const selectedIdx = i;
                             const temp = gnbMenu.map((v) => {
                                 if (v.id === selectedIdx) {
                                     return { ...v, isSelected: true };

--- a/src/component/Main/ProductSummary.tsx
+++ b/src/component/Main/ProductSummary.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from "react";
+
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { productList, paramsProductSize, reqGetProductList } from "@recoil/ProductList/index";
+
+import { reqProductList } from "@api/ProductList/index";
+
+import CProductItem from "@component/Common/CProductItem";
+import CNoContent from "@component/Common/CNoContent";
+
+function ProductSummary() {
+    const list = useRecoilValue(productList);
+    const count = useRecoilValue(paramsProductSize);
+
+    const addBookmarkStatusFn = useSetRecoilState(reqGetProductList);
+
+    useEffect(() => {
+        reqProductList({ count }).then((res) => addBookmarkStatusFn(res.data));
+    }, []);
+
+    return (
+        <div className="flex flex-nowrap w-full overflow-x-scroll">
+            {list.length > 0 ? (
+                list.slice(0, 10).map((v) => <CProductItem item={v} key={v.id} />)
+            ) : (
+                <CNoContent message={"상품이 없습니다 🥲"} />
+            )}
+        </div>
+    );
+}
+
+export default ProductSummary;

--- a/src/component/ProductList/ProductModal.tsx
+++ b/src/component/ProductList/ProductModal.tsx
@@ -1,16 +1,10 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { useSceenWidthAndHeight } from "@hook/useScreenWidthAndHeight";
 
-import { useSetRecoilState } from "recoil";
-import { changeIsBookmarkedStatus } from "@recoil/ProductList";
-import { addBookmark, removeBookmark } from "@recoil/Bookmark";
-
-import { useToast } from "@hook/useToast";
-
-import { AiFillStar } from "react-icons/ai";
 import { IoClose } from "react-icons/io5";
 
 import { IProductItemWithBookmark } from "@type/ProductList";
+import CBookmarkBtn from "@component/Common/CBookmarkBtn";
 
 function ProductModal({
     title,
@@ -27,34 +21,6 @@ function ProductModal({
 }) {
     const screenRect = useSceenWidthAndHeight();
 
-    const { fireToast } = useToast();
-    const addBookmarkFn = useSetRecoilState(addBookmark);
-    const removeBookmarkFn = useSetRecoilState(removeBookmark);
-
-    const changeIsBookmarkedStatusFn = useSetRecoilState(changeIsBookmarkedStatus(item.id));
-
-    const handleBookmarkClick = (e: React.MouseEvent<HTMLElement>) => {
-        e.stopPropagation();
-
-        let content = { color: "", text: "" };
-        if (isBookmarked) {
-            removeBookmarkFn([{ ...item }]);
-            content = { color: "#e8e8e8", text: "상품이 북마크에서 삭제되었습니다" };
-        } else {
-            addBookmarkFn([{ ...item, isBookmarked: true }]);
-            content = { color: "#FFD361", text: "상품이 북마크에 추가되었습니다" };
-        }
-        fireToast({
-            content: (
-                <div className="flex items-center">
-                    <AiFillStar size={"2rem"} color={content.color} />
-                    <p>{content.text}</p>
-                </div>
-            ),
-        });
-        changeIsBookmarkedStatusFn([]);
-    };
-
     return (
         <div
             className="relative object-cover rounded-xl overflow-hidden"
@@ -65,9 +31,7 @@ function ProductModal({
                 <IoClose size={"2rem"} color="#ffffff" />
             </button>
             <div className="flex items-center absolute bottom-3 left-3">
-                <button className="mr-2" onClick={handleBookmarkClick}>
-                    <AiFillStar size={"2rem"} color="#e8e8e8" />
-                </button>
+                <CBookmarkBtn btnStyle="mr-2" isBookmarked={isBookmarked} item={item} />
                 <span className="text-white">{title}</span>
             </div>
         </div>

--- a/src/component/ProductList/ProductModal.tsx
+++ b/src/component/ProductList/ProductModal.tsx
@@ -1,19 +1,59 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { useSceenWidthAndHeight } from "@hook/useScreenWidthAndHeight";
 
+import { useSetRecoilState } from "recoil";
+import { changeIsBookmarkedStatus } from "@recoil/ProductList";
+import { addBookmark, removeBookmark } from "@recoil/Bookmark";
+
+import { useToast } from "@hook/useToast";
+
 import { AiFillStar } from "react-icons/ai";
 import { IoClose } from "react-icons/io5";
+
+import { IProductItemWithBookmark } from "@type/ProductList";
 
 function ProductModal({
     title,
     img,
     setIsOpen,
+    isBookmarked,
+    item,
 }: {
     title: string,
     img: string,
     setIsOpen: Dispatch<SetStateAction<boolean>>,
+    isBookmarked: boolean,
+    item: IProductItemWithBookmark,
 }) {
     const screenRect = useSceenWidthAndHeight();
+
+    const { fireToast } = useToast();
+    const addBookmarkFn = useSetRecoilState(addBookmark);
+    const removeBookmarkFn = useSetRecoilState(removeBookmark);
+
+    const changeIsBookmarkedStatusFn = useSetRecoilState(changeIsBookmarkedStatus(item.id));
+
+    const handleBookmarkClick = (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
+
+        let content = { color: "", text: "" };
+        if (isBookmarked) {
+            removeBookmarkFn([{ ...item }]);
+            content = { color: "#e8e8e8", text: "상품이 북마크에서 삭제되었습니다" };
+        } else {
+            addBookmarkFn([{ ...item, isBookmarked: true }]);
+            content = { color: "#FFD361", text: "상품이 북마크에 추가되었습니다" };
+        }
+        fireToast({
+            content: (
+                <div className="flex items-center">
+                    <AiFillStar size={"2rem"} color={content.color} />
+                    <p>{content.text}</p>
+                </div>
+            ),
+        });
+        changeIsBookmarkedStatusFn([]);
+    };
 
     return (
         <div
@@ -25,7 +65,7 @@ function ProductModal({
                 <IoClose size={"2rem"} color="#ffffff" />
             </button>
             <div className="flex items-center absolute bottom-3 left-3">
-                <button className="mr-2">
+                <button className="mr-2" onClick={handleBookmarkClick}>
                     <AiFillStar size={"2rem"} color="#e8e8e8" />
                 </button>
                 <span className="text-white">{title}</span>

--- a/src/container/BookmarkList.tsx
+++ b/src/container/BookmarkList.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
-import { productItemWithBookmark } from "@recoil/Bookmark";
+import { filterBookmarkListByType } from "@recoil/Bookmark";
 
 import CProductItem from "@component/Common/CProductItem";
 import Gnb from "@component/Global/Gnb";
 
 function BookmarkList({ isMain }: { isMain: boolean }) {
-    const bookmarkList = useRecoilValue(productItemWithBookmark);
+    const bookmarkList = useRecoilValue(filterBookmarkListByType);
 
     const NoBookmarkList = () => (
         <div className="flex justify-center items-center w-screen h-210px">북마크된 상품이 없습니다 🥲</div>

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import ProductList from "@container/ProductList";
+import ProductSummary from "@component/Main/ProductSummary";
 import BookmarkList from "./BookmarkList";
 
 function Main() {
@@ -13,7 +13,7 @@ function Main() {
                         <p>더보기 +</p>
                     </Link>
                 </div>
-                <ProductList isMain={true} />
+                <ProductSummary />
             </section>
             <section className="mb-3">
                 <div className="flex justify-between items-center">

--- a/src/container/ProductList.tsx
+++ b/src/container/ProductList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 
 import { useRecoilValue, useSetRecoilState } from "recoil";
-import { productList, reqGetProductList } from "@recoil/ProductList/index";
+import { filterProductListByType, reqGetProductList } from "@recoil/ProductList/index";
 
 import { reqAllProductList } from "@api/ProductList/index";
 
@@ -10,7 +10,7 @@ import CProductItem from "@component/Common/CProductItem";
 import CNoContent from "@component/Common/CNoContent";
 
 function ProductList() {
-    const list = useRecoilValue(productList);
+    const productList = useRecoilValue(filterProductListByType);
 
     const addBookmarkStatusFn = useSetRecoilState(reqGetProductList);
 
@@ -22,8 +22,8 @@ function ProductList() {
         <div>
             <Gnb />
             <div className="flex flex-wrap justify-center">
-                {list.length > 0 ? (
-                    list.map((v) => <CProductItem item={v} key={v.id} />)
+                {productList.length > 0 ? (
+                    productList.map((v) => <CProductItem item={v} key={v.id} />)
                 ) : (
                     <CNoContent message={"상품이 없습니다 🥲"} />
                 )}

--- a/src/container/ProductList.tsx
+++ b/src/container/ProductList.tsx
@@ -1,39 +1,34 @@
-import React from "react";
-import { useRecoilValue } from "recoil";
-import { reqGetProductList } from "@recoil/ProductList/index";
+import React, { useEffect } from "react";
 
-import CProductItem from "@component/Common/CProductItem";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { productList, reqGetProductList } from "@recoil/ProductList/index";
+
+import { reqAllProductList } from "@api/ProductList/index";
+
 import Gnb from "@component/Global/Gnb";
+import CProductItem from "@component/Common/CProductItem";
+import CNoContent from "@component/Common/CNoContent";
 
-function ProductList({ isMain }: { isMain: boolean }) {
-    const productList = useRecoilValue(reqGetProductList);
-    const NoProductList = () => (
-        <div className="flex justify-center items-center w-screen h-210px">상품이 없습니다 🥲</div>
-    );
+function ProductList() {
+    const list = useRecoilValue(productList);
+
+    const addBookmarkStatusFn = useSetRecoilState(reqGetProductList);
+
+    useEffect(() => {
+        reqAllProductList().then((res) => addBookmarkStatusFn(res.data));
+    }, []);
 
     return (
-        <>
-            {isMain ? (
-                <div className="flex flex-nowrap w-full overflow-x-scroll">
-                    {productList.length > 0 ? (
-                        productList.slice(0, 10).map((v) => <CProductItem item={v} key={v.id} />)
-                    ) : (
-                        <NoProductList />
-                    )}
-                </div>
-            ) : (
-                <div>
-                    <Gnb />
-                    <div className="flex flex-wrap justify-center">
-                        {productList.length > 0 ? (
-                            productList.map((v) => <CProductItem item={v} key={v.id} />)
-                        ) : (
-                            <NoProductList />
-                        )}
-                    </div>
-                </div>
-            )}
-        </>
+        <div>
+            <Gnb />
+            <div className="flex flex-wrap justify-center">
+                {list.length > 0 ? (
+                    list.map((v) => <CProductItem item={v} key={v.id} />)
+                ) : (
+                    <CNoContent message={"상품이 없습니다 🥲"} />
+                )}
+            </div>
+        </div>
     );
 }
 

--- a/src/hook/useProductInfo.ts
+++ b/src/hook/useProductInfo.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "react";
+import { IProductInfo, IProductItemWithBookmark } from "@type/ProductList";
+import { PRODUCT_TYPE } from "@constant/ProductList";
+
+export const useProductInfo = ({ item }: { item: IProductItemWithBookmark }) => {
+    // prettier-ignore
+    const [productInfo, setProductInfo] = useState<IProductInfo>({});
+    const { title, sub_title, price, image_url, brand_name, brand_image_url, follower, discountPercentage, type } =
+        item;
+
+    useEffect(() => {
+        setProductInfo(infoWidthCategory());
+    }, []);
+
+    const infoWidthCategory = () => {
+        if (type === PRODUCT_TYPE.PRODUCT) {
+            return {
+                title: title,
+                subTitle: sub_title,
+                info: `${discountPercentage || 0}%`,
+                subInfo: `${Number.parseInt(price || "0").toLocaleString()}원`,
+                img: image_url,
+            };
+        }
+
+        if (type === PRODUCT_TYPE.CATEGORY) {
+            return {
+                title: `#${title}`,
+                subTitle: "",
+                info: "",
+                subInfo: "",
+                img: image_url,
+            };
+        }
+
+        if (type === PRODUCT_TYPE.EXHIBITION) {
+            return {
+                title: title,
+                subTitle: "",
+                info: `${discountPercentage || 0}%`,
+                subInfo: "",
+                img: image_url,
+            };
+        }
+
+        if (type === PRODUCT_TYPE.BRAND) {
+            return {
+                title: brand_name,
+                subTitle: "",
+                info: "관심고객수",
+                subInfo: `${(follower || 0).toLocaleString()}명`,
+                img: brand_image_url,
+            };
+        }
+
+        return {};
+    };
+
+    return productInfo;
+};

--- a/src/hook/useToast.ts
+++ b/src/hook/useToast.ts
@@ -5,7 +5,7 @@ import { getRandomID } from "@util/getRandomId";
 
 import { Toast } from "@type/Global";
 
-export function useToast() {
+export const useToast = () => {
     const toasts = useRecoilValue(toastState);
     const id = getRandomID();
     const addToastItemFn = useSetRecoilState(addToastItem);
@@ -34,4 +34,4 @@ export function useToast() {
     };
 
     return { toasts, fireToast };
-}
+};

--- a/src/recoil/Bookmark/index.ts
+++ b/src/recoil/Bookmark/index.ts
@@ -1,5 +1,5 @@
-import { DefaultValue, atom, selectorFamily, SerializableParam, selector } from "recoil";
-import { IProductItemWithBookmark, IProductItem } from "@type/ProductList";
+import { atom, selector } from "recoil";
+import { IProductItemWithBookmark } from "@type/ProductList";
 import { selectedGnbType } from "@recoil/Global";
 
 const localStorageEffect = (key: string) => ({ setSelf, onSet }: any) => {
@@ -17,30 +17,32 @@ const localStorageEffect = (key: string) => ({ setSelf, onSet }: any) => {
   };
 
 export const productItemWithBookmark = atom<IProductItemWithBookmark[]>({
-  key: "productItemWithBookmark",
-  default: [] as IProductItemWithBookmark[],
-  effects: [localStorageEffect("bookmarks")],
+    key: "productItemWithBookmark",
+    default: [] as IProductItemWithBookmark[],
+    effects: [localStorageEffect("bookmarks")],
 });
 
 export const addBookmark = selector({
-  key: "addBookmark",
-  get: ({ get }) => { 
-      return get(productItemWithBookmark);
-  },
-  set: ({ set }, newBookmark) => {
-    set(productItemWithBookmark, prevBookmark => [...prevBookmark, ...newBookmark as []]);
-  },
+    key: "addBookmark",
+    get: ({ get }) => { 
+        return get(productItemWithBookmark);
+    },
+    set: ({ set }, newBookmark) => {
+      set(productItemWithBookmark, prevBookmark => [...prevBookmark, ...newBookmark as []]);
+    },
 })
 
 export const removeBookmark = selector({
-  key: "removeBookmark",
-  get: ({ get }) => { 
-      return get(productItemWithBookmark);
-  },
-  set: ({ set }, deletedBookmark) => {
-    const deleteId = Array.isArray(deletedBookmark) ? deletedBookmark[0]?.id : undefined;
-      set(productItemWithBookmark, prevBookmark => prevBookmark.filter((v: IProductItemWithBookmark) => v.id && v.id !== deleteId));
-  },
+    key: "removeBookmark",
+    get: ({ get }) => { 
+        return get(productItemWithBookmark);
+    },
+    set: ({ set }, deletedBookmark) => {
+      const deleteId = Array.isArray(deletedBookmark) ? deletedBookmark[0]?.id : undefined;
+        set(productItemWithBookmark, prevBookmark => prevBookmark.filter((v: IProductItemWithBookmark) => v.id && v.id !== deleteId));
+    },
+})
+
 // 상품 타입에 따라 북마크 리스트 데이터를 필터하여 화면에 뿌리기 위한 get 함수
 export const filterBookmarkListByType = selector({
     key: "filterBookmarkListByType",

--- a/src/recoil/Bookmark/index.ts
+++ b/src/recoil/Bookmark/index.ts
@@ -1,5 +1,6 @@
 import { DefaultValue, atom, selectorFamily, SerializableParam, selector } from "recoil";
 import { IProductItemWithBookmark, IProductItem } from "@type/ProductList";
+import { selectedGnbType } from "@recoil/Global";
 
 const localStorageEffect = (key: string) => ({ setSelf, onSet }: any) => {
     const savedValue = localStorage.getItem(key);
@@ -40,4 +41,15 @@ export const removeBookmark = selector({
     const deleteId = Array.isArray(deletedBookmark) ? deletedBookmark[0]?.id : undefined;
       set(productItemWithBookmark, prevBookmark => prevBookmark.filter((v: IProductItemWithBookmark) => v.id && v.id !== deleteId));
   },
+// 상품 타입에 따라 북마크 리스트 데이터를 필터하여 화면에 뿌리기 위한 get 함수
+export const filterBookmarkListByType = selector({
+    key: "filterBookmarkListByType",
+    get: ({ get }) => {
+        const temp = get(productItemWithBookmark);
+        const type = get(selectedGnbType);
+        
+        if (type === '') return temp;
+
+        return temp.filter(v => v.type === type);
+    }
 })

--- a/src/recoil/Global/index.ts
+++ b/src/recoil/Global/index.ts
@@ -12,6 +12,11 @@ export const toastState = atom<Toast[]>({
   default: [],
 });
 
+export const selectedGnbType = atom<string>({
+    key: "selectedGnbType",
+    default: "",
+})
+
 // ==================================================================================================================================
 // select의 set 코드
 // 현재 상황에서의 장점

--- a/src/recoil/Global/index.ts
+++ b/src/recoil/Global/index.ts
@@ -8,8 +8,8 @@ export const dropdownShow = atom<boolean>({
 });
 
 export const toastState = atom<Toast[]>({
-  key: 'toastState',
-  default: [],
+    key: 'toastState',
+    default: [],
 });
 
 export const selectedGnbType = atom<string>({
@@ -31,20 +31,20 @@ export const selectedGnbType = atom<string>({
 
 // 기능 1. toastItem 추가
 export const addToastItem = selector({
-  key: "addToastItem",
-  get: ({ get }) => get(toastState),
-  set: ({ set }, newToast: Toast[] | DefaultValue) => {
-    set(toastState, prevToast => [...prevToast, ...newToast as []]);
-  },
+    key: "addToastItem",
+    get: ({ get }) => get(toastState),
+    set: ({ set }, newToast: Toast[] | DefaultValue) => {
+      set(toastState, prevToast => [...prevToast, ...newToast as []]);
+    },
 })
 // 기능 2. id에 해당하는 toastItem 삭제
 export const removeToastItem = selector({
-  key: "removeToastItem",
-  get: ({ get }) => get(toastState),
-  set: ({ set }, deletedToast: Toast[] | DefaultValue) => {
-      const deleteId = Array.isArray(deletedToast) ? deletedToast[0]?.id : undefined;
-      set(toastState, prevToast => prevToast.filter((v: Toast) => v.id && v.id !== deleteId));
-  },
+    key: "removeToastItem",
+    get: ({ get }) => get(toastState),
+    set: ({ set }, deletedToast: Toast[] | DefaultValue) => {
+        const deleteId = Array.isArray(deletedToast) ? deletedToast[0]?.id : undefined;
+        set(toastState, prevToast => prevToast.filter((v: Toast) => v.id && v.id !== deleteId));
+    },
 })
 // useToast hook 코드
 // export function useToast() {

--- a/src/recoil/ProductList/index.ts
+++ b/src/recoil/ProductList/index.ts
@@ -1,6 +1,7 @@
 import { atom, selector, selectorFamily } from "recoil";
 
 import { IProductItemWithBookmark } from "@type/ProductList";
+import { selectedGnbType } from "@recoil/Global";
 
 export const paramsProductSize = atom({
     key: "paramsProductSize",
@@ -51,5 +52,18 @@ export const changeIsBookmarkedStatus = selectorFamily({
         
         const changeedBookmarkStatus = temp.map((v) => (v.id === productId ? { ...v, isBookmarked: !v.isBookmarked } : v));
         set(productList, changeedBookmarkStatus);
+    }
+})
+
+// 상품 타입에 따라 상품 리스트 데이터를 필터하여 화면에 뿌리기 위한 get 함수
+export const filterProductListByType = selector({
+    key: "filterProductListByType",
+    get: ({ get }) => {
+        const temp = get(productList);
+        const type = get(selectedGnbType);
+
+        if (type === '') return temp;
+
+        return temp.filter(v => v.type === type);
     }
 })

--- a/src/recoil/ProductList/index.ts
+++ b/src/recoil/ProductList/index.ts
@@ -1,31 +1,55 @@
-import { atom, selector } from "recoil";
-import { reqProductList } from "@api/ProductList/index";
-import { IProductItem, IProductItemWithBookmark } from "@type/ProductList";
-import { productItemWithBookmark } from "@recoil/Bookmark";
+import { atom, selector, selectorFamily } from "recoil";
+
+import { IProductItemWithBookmark } from "@type/ProductList";
 
 export const paramsProductSize = atom({
     key: "paramsProductSize",
     default: 10,
 });
 
-// prettier-ignore
+// 상품 리스트 api 응답 결과를 저장할 atom
+export const productList = atom<IProductItemWithBookmark[]>({
+    key: "productList",
+    default: []
+});
+
+// 상품 리스트 api 응답 결과에 북마크 여부를 포함하여 productList 상태를 set 할 함수
 export const reqGetProductList = selector<IProductItemWithBookmark[]>({
     key: "reqGetProductList",
     get: async ({ get }) => {
-        const response = await reqProductList({
-            count: get(paramsProductSize),
-        });
-
+        return get(productList);
+    },
+    set: ({ set }, productListWithoutBookmark) => {
         const savedValue = localStorage.getItem("bookmarks");
         let paredSavedValue = [];
         if (savedValue) {
-            paredSavedValue = JSON.parse(savedValue)
+            paredSavedValue = JSON.parse(savedValue);
         }
         
         const bookmarkIds = paredSavedValue.map((v: IProductItemWithBookmark) => v.id);
 
-        const data: Array<IProductItem> = response.data;
-        const addBookmarkStatus = data.map((v) => bookmarkIds.includes(v.id) ? {...v, isBookmarked: true} : v);
-        return addBookmarkStatus;
-    },
+        let data: IProductItemWithBookmark[] = []
+        if (Array.isArray(productListWithoutBookmark)) {
+            data = productListWithoutBookmark;
+        }
+        const addBookmarkStatus = data.map((v) => bookmarkIds.includes(v.id) ? { ...v, isBookmarked: true } : v);
+        set(productList, addBookmarkStatus);
+    }
 });
+
+// 전달받은 상품의 id에 해당하는 상품의 북마크 여부를 수정할 set 함수
+export const changeIsBookmarkedStatus = selectorFamily({
+    key: "changeIsBookmarkedStatus",
+    get: (productId: number) => ({ get }) => {
+        const temp = get(productList);
+
+        const changeedBookmarkStatus = temp.map((v) => (v.id === productId ? { ...v, isBookmarked: !v.isBookmarked } : v));
+        return changeedBookmarkStatus;
+    },
+    set: (productId: number) => ({ get, set }) => {
+        const temp = get(productList);
+        
+        const changeedBookmarkStatus = temp.map((v) => (v.id === productId ? { ...v, isBookmarked: !v.isBookmarked } : v));
+        set(productList, changeedBookmarkStatus);
+    }
+})

--- a/src/type/Global/index.ts
+++ b/src/type/Global/index.ts
@@ -4,3 +4,11 @@ export interface Toast {
     duration?: number;
     bottom?: number;
 }
+
+export interface IGnbItems {
+    id: number;
+    label: string;
+    type: string;
+    img: string;
+    isSelected: boolean;
+}


### PR DESCRIPTION
### [어디까지 구현했는지]
- 프로젝트 세팅 + Header, Footer, GNB, 각 상품 아이템, 모달 컴포넌트 + recoil 세팅 & 데이터 가져오기
- 에러가 발견된 북마크 컴포넌트

### [현재 어딜 구현하고 있는지]
issue #25 
북마크 관련 에러를 수정하며 코드 길이가 긴 컴포넌트에 대해 리팩토링을 진행하였습니다.

**북마크 관련하여 발견한 에러: 북마크 리스트에서 북마크 상태를 변경할 경우 상품 리스트 컴포넌트에 반영되지 않는 에러를 발견하였습니다.(북마크 해제 후에도 여전히 노란색 별)**

https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/7aa174c2-0da1-4c7b-b0ba-bb7d18bbb66f

**에러 원인: 상품리스트에서 보여주는 데이터는 selector의 get 함수를 사용하여 상태를 저장하지 않은 채 바로 화면에 뿌려줍니다.**
**에러 발생 상황: 상품리스트 데이터는 저장되지 않으므로 북마크 상태가 바뀌었을 때 북마크 상태만 바꿔줄 수 없었습니다.**
**해결 방법: 상품리스트 데이터를 저장하여 북마크 상태가 변경될 때 상품 리스트 데이터를 바꿔줄 selectorFamily set 함수를 만들고 사용합니다.**

다음은 수정 후 화면입니다. 북마크 리스트에서 북마크 상태를 해제할 경우 상품 리스트에도 별이 회색으로 변하는 것을 확인할 수 있습니다.

https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/57cf921a-8154-4add-9a7e-f61f8c39fb5c





### [앞으로 어딜 구현할 것인지]
- 북마크 버튼에 debounce 또는 throttle 적용

### [집중적으로 코드 리뷰를 받고 싶거나 궁금한 부분]
- 북마크 버튼 클릭 시 북마크 리스트 데이터, 상품 리스트 데이터, 로컬 스토리지의 상태가 변경됩니다.
- 따라서 북마크 버튼을 연속으로 누를 경우 성능이 저하될 가능성이 크다고 판단하여 debounce 또는 throttle를 적용하려 합니다.
- 이 글 ([Throttle 와 Debounce 개념 정리하기](https://pks2974.medium.com/throttle-%EC%99%80-debounce-%EA%B0%9C%EB%85%90-%EC%A0%95%EB%A6%AC%ED%95%98%EA%B8%B0-2335a9c426ff))을 통해 그 차이점에 대해 보았지만, 북마크 버튼 연속 클릭을 막기 위해 어떤 것을 사용하는 것이 좋을지 고민됩니다.
- throttle과 debounce 어떤 것을 쓰는 것이 더 좋을까요?
