### PR TITLE
🔨 11_스크롤_이벤트_구현)

### DIFF
--- a/src/component/Common/CDropDown.tsx
+++ b/src/component/Common/CDropDown.tsx
@@ -5,10 +5,10 @@ import { useRecoilValue } from "recoil";
 function CDropDown({ height, children }: { height: string, children: JSX.Element }) {
     const show = useRecoilValue(dropdownShow);
 
-    const triangleBeforeCss = `before:content-[''] before:absolute before:w-0 before:h-0 before:z-30 before:-top-0 before:left-3/4
+    const triangleBeforeCss = `before:content-[''] before:absolute before:w-0 before:h-0 before:z-40 before:-top-0 before:left-3/4
         before:border-t-0 before:border-b-16px before:border-b-light-black
         before:border-l-8 before:border-l-transparent before:border-r-8 before:border-r-transparent`;
-    const triangleAfterCss = `after:content-[''] after:absolute after:w-0 after:h-0 after:z-40 after:top-1 after:left-3/4
+    const triangleAfterCss = `after:content-[''] after:absolute after:w-0 after:h-0 after:z-50 after:top-1 after:left-3/4
         after:border-t-0 after:border-b-16px after:border-b-white
         after:border-l-8 after:border-l-transparent after:border-r-8 after:border-r-transparent`;
 
@@ -17,7 +17,7 @@ function CDropDown({ height, children }: { height: string, children: JSX.Element
     return (
         <div
             style={{ height: `${show ? height : "0"}`, transition: "height ease-out 100ms 0s" }}
-            className={`absolute z-20 right-52px w-max overflow-hidden ${triangleBeforeCss} ${triangleAfterCss}`}
+            className={`absolute z-30 right-52px w-max overflow-hidden ${triangleBeforeCss} ${triangleAfterCss}`}
         >
             <ol className={`${olDefaultCss}`}>{children}</ol>
         </div>

--- a/src/component/Common/CDropDown.tsx
+++ b/src/component/Common/CDropDown.tsx
@@ -1,9 +1,10 @@
 import React from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { dropdownShow } from "@recoil/Global";
-import { useRecoilValue } from "recoil";
 
 function CDropDown({ height, children }: { height: string, children: JSX.Element }) {
     const show = useRecoilValue(dropdownShow);
+    const setDropdownShow = useSetRecoilState(dropdownShow);
 
     const triangleBeforeCss = `before:content-[''] before:absolute before:w-0 before:h-0 before:z-40 before:-top-0 before:left-3/4
         before:border-t-0 before:border-b-16px before:border-b-light-black
@@ -16,6 +17,7 @@ function CDropDown({ height, children }: { height: string, children: JSX.Element
 
     return (
         <div
+            onClick={() => setDropdownShow(false)}
             style={{ height: `${show ? height : "0"}`, transition: "height ease-out 100ms 0s" }}
             className={`absolute z-30 right-52px w-max overflow-hidden ${triangleBeforeCss} ${triangleAfterCss}`}
         >

--- a/src/component/Global/Gnb.tsx
+++ b/src/component/Global/Gnb.tsx
@@ -9,6 +9,8 @@ import IconBrand from "@asset/icon-category.png";
 import { useSetRecoilState } from "recoil";
 import { selectedGnbType } from "@recoil/Global";
 
+import { useScroll } from "@hook/useScroll";
+
 import { IGnbItems } from "@type/Global";
 
 function Gnb() {
@@ -53,8 +55,14 @@ function Gnb() {
     const [gnbMenu, setGnbMenu] = useState(gnbItems);
     const setSelectedType = useSetRecoilState(selectedGnbType);
 
+    const { isScrollDown } = useScroll();
+
     return (
-        <div className="flex justify-center mb-6">
+        <div
+            className={`flex justify-center items-center w-full h-28 z-10 mb-6 bg-white ${
+                isScrollDown ? "fixed top-20 left-0" : "mt-20"
+            }`}
+        >
             {gnbMenu.map((v: IGnbItems, i: number) => {
                 return (
                     <div

--- a/src/component/Global/Header.tsx
+++ b/src/component/Global/Header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, RefObject, useRef } from "react";
 import { Link } from "react-router-dom";
 
 import { useRecoilState } from "recoil";
@@ -11,7 +11,23 @@ import MenuDropDownItem from "@component/Global/MenuDropDownItem";
 import Logo from "@asset/Logo.png";
 
 function Header() {
+    // prettier-ignore
+    const dropdownRef: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
     const [isDropDownShow, setIsDropDownShow] = useRecoilState(dropdownShow);
+
+    useEffect(() => {
+        const outsideClick = (e: MouseEvent) => {
+            if (isDropDownShow && !dropdownRef.current?.contains(e.target as Node)) {
+                setIsDropDownShow(false);
+            }
+        };
+
+        document.body.addEventListener("click", outsideClick);
+
+        return () => {
+            document.body.removeEventListener("click", outsideClick);
+        };
+    }, [isDropDownShow]);
 
     return (
         <header className="flex justify-between items-center fixed w-full h-20 z-20 px-76px bg-white">
@@ -25,13 +41,18 @@ function Header() {
             </Link>
 
             <div className="relatvie z-20">
-                <button className="cursor-pointer" onClick={() => setIsDropDownShow(!isDropDownShow)}>
+                <button className="cursor-pointer" onClick={(e) => {
+                    e.stopPropagation();
+                    setIsDropDownShow(!isDropDownShow);
+                }}>
                     <GiHamburgerMenu size={"2rem"} />
                 </button>
 
-                <CDropDown height="170px">
-                    <MenuDropDownItem />
-                </CDropDown>
+                <div ref={dropdownRef} onClick={(e) => e.stopPropagation()}>
+                    <CDropDown height="170px">
+                        <MenuDropDownItem />
+                    </CDropDown>
+                </div>
             </div>
         </header>
     );

--- a/src/component/Global/Header.tsx
+++ b/src/component/Global/Header.tsx
@@ -14,7 +14,7 @@ function Header() {
     const [isDropDownShow, setIsDropDownShow] = useRecoilState(dropdownShow);
 
     return (
-        <header className="flex justify-between items-center w-full h-20 px-76px">
+        <header className="flex justify-between items-center fixed w-full h-20 z-20 px-76px bg-white">
             <Link to="/">
                 <div className="flex items-center cursor-pointer">
                     <div className="w-55px h-30px pr-3">
@@ -24,7 +24,7 @@ function Header() {
                 </div>
             </Link>
 
-            <div className="relatvie z-10">
+            <div className="relatvie z-20">
                 <button className="cursor-pointer" onClick={() => setIsDropDownShow(!isDropDownShow)}>
                     <GiHamburgerMenu size={"2rem"} />
                 </button>

--- a/src/container/Main.tsx
+++ b/src/container/Main.tsx
@@ -6,7 +6,7 @@ import BookmarkList from "./BookmarkList";
 function Main() {
     return (
         <>
-            <section className="mb-6">
+            <section className="mt-20 mb-6">
                 <div className="flex justify-between items-center">
                     <p className="mb-3 text-2xl">상품 리스트</p>
                     <Link to="/products/list">

--- a/src/hook/useScroll.ts
+++ b/src/hook/useScroll.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useMemo } from "react";
+import _ from "lodash";
+
+export function useScroll() {
+    let beforeScrollY = 0;
+    const [isScrollDown, setIsScrollDown] = useState(false);
+
+    const scrollEvent = useMemo(
+        () =>
+            _.throttle(() => {
+                const curScrollY = window.scrollY;
+                if (curScrollY === 0) {
+                    setIsScrollDown(false);
+                } else if (curScrollY > beforeScrollY) {
+                    setIsScrollDown(false);
+                } else {
+                    setIsScrollDown(true);
+                }
+
+                beforeScrollY = curScrollY;
+            }, 300),
+        [isScrollDown],
+    );
+
+    useEffect(() => {
+        window.addEventListener("scroll", scrollEvent);
+
+        return () => {
+            window.removeEventListener("scroll", scrollEvent);
+        };
+    }, []);
+
+    return { isScrollDown };
+}

--- a/src/recoil/Global/index.ts
+++ b/src/recoil/Global/index.ts
@@ -22,6 +22,8 @@ export const selectedGnbType = atom<string>({
 // 현재 상황에서의 장점
 // 1. 아래 코드와 달리 컴포넌트 상단에서 useToast 를 호출하는 순간 Toast 객체를 넘겨주는 것이 아닌
 // 이벤트 핸들러에서 fireToast 함수를 호출하는 시점에서 Toast 객체를 넘겨주기 때문에 toast의 content에 대한 상태관리를 할 필요가 없다.
+// 2. getter는 그럴 수 있어. 하지만 setter는 그러면 안돼.
+// -> DDD (Domain Driven) -> 그래서 의미가 있는 setter가 되어야 합니다!
 
 // 현재 상황에서의 단점
 // 2. ({set}, temp) 여기서 temp에 해당하는 인자의 타입은 Toast[] 또는 DefaultValue


### PR DESCRIPTION
### [어디까지 구현했는지]
- 프로젝트 세팅 + Header, Footer, GNB, 각 상품 아이템, 모달 컴포넌트 + recoil 세팅 & 데이터 가져오기

### [현재 어딜 구현하고 있는지]
issue #23 
- 헤더가 고정되도록 하였습니다.
- 스크롤을 아래로 내릴 때 GNB가 안보이도록, 스크롤을 위로 올릴 때 GNB가 보이도록 수정하였습니다.
- 메뉴 버튼 외의 영역을 눌렀을 때 드롭드운이 사라지도록 하였습니다.

https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/00fce724-91cd-4c66-8dfc-d5030fd85710


### [앞으로 어딜 구현할 것인지]
- 로딩 컴포넌트

### [집중적으로 코드 리뷰를 받고 싶거나 궁금한 부분]

