### PR TITLE
🐛 13 북마크 중복 에러 수정)

### DIFF
--- a/src/recoil/Bookmark/index.ts
+++ b/src/recoil/Bookmark/index.ts
@@ -27,12 +27,28 @@ export const productItemWithBookmark = atom<IProductItemWithBookmark[]>({
 
 export const addBookmark = selector({
     key: "addBookmark",
-    get: ({ get }) => { 
+    get: ({ get }) => {
         return get(productItemWithBookmark);
     },
-  set: ({ set }, newBookmark) => {
-      // TODO 북마크 리스트를 맵으로 관리가 되어야하는 건 아닌가!
-      set(productItemWithBookmark, prevBookmark => [...prevBookmark, ...newBookmark as []]);
+    set: ({ set }, newBookmark) => {
+        set(productItemWithBookmark, (prevBookmark) => {
+            let newBookmarkObj = { id: -1 };
+            if (Array.isArray(newBookmark)) {
+                newBookmarkObj = newBookmark[0];
+            }
+
+            // 새로운 북마크 객체에 id가 없을 경우
+            if (newBookmarkObj.id === -1) {
+                return prevBookmark;
+            }
+
+            // 북마크 배열에 이미 새로운 북마크 객체의 id가 존재할 경우
+            if (prevBookmark.filter((v) => v.id === newBookmarkObj.id).length > 0) {
+                return prevBookmark;
+            }
+
+            return [...prevBookmark, ...newBookmark as []];
+      });
     },
 })
 
@@ -42,7 +58,7 @@ export const removeBookmark = selector({
         return get(productItemWithBookmark);
     },
     set: ({ set }, deletedBookmark) => {
-      const deleteId = Array.isArray(deletedBookmark) ? deletedBookmark[0]?.id : undefined;
+        const deleteId = Array.isArray(deletedBookmark) ? deletedBookmark[0]?.id : undefined;
         set(productItemWithBookmark, prevBookmark => prevBookmark.filter((v: IProductItemWithBookmark) => v.id && v.id !== deleteId));
     },
 })


### PR DESCRIPTION
### [어디까지 구현했는지]
- 프로젝트 세팅 + Header, Footer, GNB, 각 상품 아이템, 모달 컴포넌트 + recoil 세팅 & 데이터 가져오기 + husky 세팅

### [현재 어딜 구현하고 있는지]
issues #29 

### 에러 화면
![image](https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/62a50e26-9eae-4ae5-9789-854755ee09f2)

### 기존에 수정하려했던 방법
- set 객체 사용
  - set 객체로 중복을 제거하려고 하였으나 객체 리스트에 담기는 상품 정보는 object로 저장되는, 즉 referece type이기 때문에 같은 내용을 담고 있는 object도 같지 않다고 판단하여 중복 제거 실패
- map 객체 사용
  - 상품의 id를 key로 가지고 있는 map 객체 형태로 저장하려고 하였으나, 상품을 보여주는 공통 컴포넌트를 사용하려면 결국 배열로 저장하는 것이 가장 편하다고 판단

### 북마크 리스트에 추가하는 set 함수 수정
- 이미 담으려는 북마크 상품의 id가 있을 경우 담지 않도록 수정

https://github.com/kay0829/fe-sprint-coz-shopping/assets/126226314/69b9710a-eeb7-4669-80ba-cdf196478736



### [앞으로 어딜 구현할 것인지]


### [집중적으로 코드 리뷰를 받고 싶거나 궁금한 부분]

